### PR TITLE
Reuse send connection

### DIFF
--- a/src/MessageCounter.php
+++ b/src/MessageCounter.php
@@ -1,0 +1,91 @@
+<?php namespace Ipunkt\LaravelRabbitMQ;
+
+use PhpAmqpLib\Channel\AMQPChannel;
+
+/**
+ * Class MessageCounter
+ * @package Ipunkt\LaravelRabbitMQ
+ */
+class MessageCounter {
+
+	/**
+	 * @var string
+	 */
+	protected $queueName;
+
+	/**
+	 * @var AMQPChannel
+	 */
+	protected $channel;
+
+	/**
+	 * @var int
+	 */
+	protected $counter = 0;
+
+	/**
+	 * MessageCounter constructor.
+	 * @param string $queueName
+	 */
+	public function __construct(string $queueName) {
+		$this->queueName = $queueName;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getQueueName(): string {
+		return $this->queueName;
+	}
+
+	/**
+	 * @param string $queueName
+	 * @return MessageCounter
+	 */
+	public function setQueueName( string $queueName ): MessageCounter {
+		$this->queueName = $queueName;
+		return $this;
+	}
+
+	/**
+	 * @return AMQPChannel
+	 */
+	public function getChannel() {
+		return $this->channel;
+	}
+
+	/**
+	 * @param AMQPChannel $channel
+	 * @return MessageCounter
+	 */
+	public function setChannel( AMQPChannel $channel ): MessageCounter {
+		$this->channel = $channel;
+		return $this;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getCounter(): int {
+		return $this->counter;
+	}
+
+	/**
+	 * @param int $counter
+	 * @return MessageCounter
+	 */
+	public function setCounter( int $counter ): MessageCounter {
+		$this->counter = $counter;
+		return $this;
+	}
+
+	/**
+	 * @return $this
+	 */
+	public function increaseCounter() {
+		++$this->counter;
+		return $this;
+	}
+
+
+}

--- a/src/RabbitMQ.php
+++ b/src/RabbitMQ.php
@@ -93,7 +93,7 @@ class RabbitMQ
 	 * @param $queueIdentifier
 	 * @return MessageCounter
 	 */
-	protected function getMessageCounter( $queueIdentifier ): array {
+	protected function getMessageCounter( $queueIdentifier ) : MessageCounter {
 
 		if ( !array_key_exists( $queueIdentifier, $this->messageCounters ) ) {
 


### PR DESCRIPTION
Reuses connections only when publishing so closing a connection does not necessitate restarting the listening process